### PR TITLE
Correction des outils et de la barre d'outils

### DIFF
--- a/src/main/java/org/graphysica/construction/Element.java
+++ b/src/main/java/org/graphysica/construction/Element.java
@@ -90,6 +90,24 @@ public abstract class Element implements Deplaceable {
     }
 
     /**
+     * Ajoute une dépendance à cet élément.
+     *
+     * @param dependance la dépendance à ajouter.
+     */
+    public void ajouter(@NotNull final Element dependance) {
+        dependances.add(dependance);
+    }
+
+    /**
+     * Retire une dépendance de cet élément.
+     *
+     * @param dependance la dépendance à retirer.
+     */
+    public void retirer(@NotNull final Element dependance) {
+        dependances.remove(dependance);
+    }
+
+    /**
      * Déplace les dépendances immédiates de cet élément pour le déplacer
      * lui-même.
      *

--- a/src/main/java/org/graphysica/construction/GestionnaireEspaces.java
+++ b/src/main/java/org/graphysica/construction/GestionnaireEspaces.java
@@ -152,7 +152,6 @@ public class GestionnaireEspaces {
      */
     private final ListChangeListener<Element> changementElements = (@NotNull
             final ListChangeListener.Change<? extends Element> changements) -> {
-        System.out.println(changements.getList().size());
         while (changements.next()) {
             changements.getAddedSubList().stream().forEach((element) -> {
                 ajouterElement(element);

--- a/src/main/java/org/graphysica/construction/GestionnaireEspaces.java
+++ b/src/main/java/org/graphysica/construction/GestionnaireEspaces.java
@@ -23,7 +23,9 @@ import java.util.Map;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.event.EventHandler;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseEvent;
+import org.apache.commons.math3.geometry.euclidean.twod.Vector2D;
 import org.graphysica.espace2d.Espace;
 import org.graphysica.espace2d.forme.Forme;
 
@@ -44,6 +46,11 @@ public class GestionnaireEspaces {
      * Les éléments de ce gestionnaire d'espaces.
      */
     private final ObservableList<Element> elements;
+
+    /**
+     * L'association des gestionnaires de navigation aux espaces.
+     */
+    private final Map<Espace, Navigation> gestionsNavigation = new HashMap<>();
 
     /**
      * L'association des gestionnaires d'entrée du curseur aux espaces.
@@ -69,9 +76,9 @@ public class GestionnaireEspaces {
         if (!espaces.isEmpty()) {
             espaceActif = espaces.get(0);
         }
-        for (final Espace espace : espaces) {
+        espaces.forEach((espace) -> {
             ajouterEspace(espace);
-        }
+        });
         this.elements = elements;
         this.espaces.addListener(changementEspaces);
         this.elements.addListener(changementElements);
@@ -98,12 +105,15 @@ public class GestionnaireEspaces {
      * @param espace l'espace à ajouter.
      */
     private void ajouterEspace(@NotNull final Espace espace) {
+        final Navigation gestionNavigation = new Navigation(espace);
+        espace.addEventFilter(KeyEvent.KEY_PRESSED, new Navigation(espace));
+        gestionsNavigation.put(espace, gestionNavigation);
         final GestionEntree gestionEntree = new GestionEntree(espace);
         espace.addEventFilter(MouseEvent.MOUSE_ENTERED, gestionEntree);
         gestionsEntree.put(espace, new GestionEntree(espace));
-        for (final Element element : elements) {
+        elements.forEach((element) -> {
             espace.getFormes().addAll(element.creerFormes());
-        }
+        });
     }
 
     /**
@@ -112,11 +122,13 @@ public class GestionnaireEspaces {
      * @param espace l'eapce à retirer.
      */
     private void retirerEspace(@NotNull final Espace espace) {
+        final Navigation gestionNavigation = gestionsNavigation.remove(espace);
+        espace.removeEventFilter(KeyEvent.KEY_PRESSED, gestionNavigation);
         final GestionEntree gestionEntree = gestionsEntree.remove(espace);
         espace.removeEventFilter(MouseEvent.MOUSE_ENTERED, gestionEntree);
-        for (final Element element : elements) {
+        elements.forEach((element) -> {
             espace.getFormes().removeAll(element.getFormes());
-        }
+        });
     }
 
     /**
@@ -140,6 +152,7 @@ public class GestionnaireEspaces {
      */
     private final ListChangeListener<Element> changementElements = (@NotNull
             final ListChangeListener.Change<? extends Element> changements) -> {
+        System.out.println(changements.getList().size());
         while (changements.next()) {
             changements.getAddedSubList().stream().forEach((element) -> {
                 ajouterElement(element);
@@ -157,9 +170,9 @@ public class GestionnaireEspaces {
      * @param element l'élément à ajouter.
      */
     private void ajouterElement(@NotNull final Element element) {
-        for (final Espace espace : espaces) {
+        espaces.forEach((espace) -> {
             espace.getFormes().addAll(element.creerFormes());
-        }
+        });
     }
 
     /**
@@ -168,9 +181,9 @@ public class GestionnaireEspaces {
      * @param element l'élément à retirer.
      */
     private void retirerElement(@NotNull final Element element) {
-        for (final Espace espace : espaces) {
+        espaces.forEach((espace) -> {
             espace.getFormes().removeAll(element.getFormes());
-        }
+        });
     }
 
     /**
@@ -203,34 +216,14 @@ public class GestionnaireEspaces {
     }
 
     /**
-     * Une gestion sur un espace.
-     */
-    private abstract class Gestion implements EventHandler<MouseEvent> {
-
-        /**
-         * L'espace de cette gestion.
-         */
-        private final Espace espace;
-
-        /**
-         * Construit une gestion sur un espace défini.
-         *
-         * @param espace l'espace à gérer.
-         */
-        public Gestion(@NotNull final Espace espace) {
-            this.espace = espace;
-        }
-
-        public Espace getEspace() {
-            return espace;
-        }
-
-    }
-
-    /**
      * Une gestion d'entrée de curseur sur un espace actualise l'espace actif.
      */
-    private class GestionEntree extends Gestion {
+    private class GestionEntree implements EventHandler<MouseEvent> {
+        
+        /**
+         * L'espace de cette gestion d'entrée d'espace.
+         */
+        private final Espace espace;
 
         /**
          * Construit une gestion d'entrée sur un espace défini.
@@ -238,12 +231,72 @@ public class GestionnaireEspaces {
          * @param espace l'espace à gérer.
          */
         public GestionEntree(@NotNull final Espace espace) {
-            super(espace);
+            this.espace = espace;
         }
 
         @Override
         public void handle(@NotNull final MouseEvent evenement) {
-            espaceActif = getEspace();
+            espaceActif = espace;
+        }
+
+    }
+
+    /**
+     * Un événement de navigation permet de naviguer un espace défini à l'aide
+     * du clavier. Il permet de zoomer l'espace avec "Ctrl+'+'" et de dézoomer
+     * avec "Ctrl+'-'", et de défiler selon un pas avec "Ctrl+'UP'",
+     * "Ctrl+'DOWN'", "Ctrl+'LEFT'" et "Ctrl+'RIGHT'" respectivement pour
+     * défiler vers le haut, le bas, la gauche et la droite.
+     */
+    private static class Navigation implements EventHandler<KeyEvent> {
+
+        /**
+         * Le pas du défilement exprimé en pixels.
+         */
+        private static final double PAS = 25;
+
+        /**
+         * L'espace de cette navigation.
+         */
+        private final Espace espace;
+
+        /**
+         * Construit un événement de navigation sur un espace défini.
+         *
+         * @param espace l'espace à naviguer.
+         */
+        public Navigation(@NotNull final Espace espace) {
+            this.espace = espace;
+        }
+
+        @Override
+        public void handle(@NotNull final KeyEvent evenement) {
+            if (evenement.isControlDown()) {
+                switch (evenement.getCode()) {
+                    case ADD:
+                    case EQUALS:
+                    case PLUS:
+                        espace.zoomer(1);
+                        break;
+                    case SUBTRACT:
+                    case UNDERSCORE:
+                    case MINUS:
+                        espace.zoomer(-1);
+                        break;
+                    case UP:
+                        espace.defiler(new Vector2D(0, PAS));
+                        break;
+                    case DOWN:
+                        espace.defiler(new Vector2D(0, -PAS));
+                        break;
+                    case LEFT:
+                        espace.defiler(new Vector2D(PAS, 0));
+                        break;
+                    case RIGHT:
+                        espace.defiler(new Vector2D(-PAS, 0));
+                        break;
+                }
+            }
         }
 
     }

--- a/src/main/java/org/graphysica/construction/GestionnaireOutils.java
+++ b/src/main/java/org/graphysica/construction/GestionnaireOutils.java
@@ -19,7 +19,6 @@ package org.graphysica.construction;
 import com.sun.istack.internal.NotNull;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
-import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;

--- a/src/main/java/org/graphysica/construction/GestionnaireOutils.java
+++ b/src/main/java/org/graphysica/construction/GestionnaireOutils.java
@@ -19,6 +19,8 @@ package org.graphysica.construction;
 import com.sun.istack.internal.NotNull;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.event.EventHandler;
@@ -95,6 +97,12 @@ public final class GestionnaireOutils {
         espaces.addListener(changementEspaces);
         espaces.forEach((espace) -> {
             ajouterGestionsOutils(espace);
+        });
+        outilActif.addListener((ObservableValue<? extends Outil> changement, 
+                final Outil ancienOutil, final Outil nouvelOutil) -> {
+            if (ancienOutil != null && ancienOutil.isEnCours()) {
+                ancienOutil.interrompre();
+            }
         });
     }
 

--- a/src/main/java/org/graphysica/construction/GestionnaireSelections.java
+++ b/src/main/java/org/graphysica/construction/GestionnaireSelections.java
@@ -364,7 +364,7 @@ public final class GestionnaireSelections {
             if (!formesSurvolees.isEmpty()) {
                 getEspace().setCursor(Cursor.HAND);
             } else {
-                getEspace().setCursor(Cursor.DEFAULT);
+                getEspace().setCursor(Cursor.CROSSHAIR);
             }
             final Iterator<Forme> iteration
                     = formesEnSurbrillance.iterator();

--- a/src/main/java/org/graphysica/construction/mathematiques/Droite.java
+++ b/src/main/java/org/graphysica/construction/mathematiques/Droite.java
@@ -19,7 +19,9 @@ package org.graphysica.construction.mathematiques;
 import com.sun.istack.internal.NotNull;
 import java.util.HashSet;
 import java.util.Set;
+import javafx.beans.property.ObjectProperty;
 import org.graphysica.espace2d.forme.Forme;
+import org.graphysica.espace2d.position.PositionReelle;
 
 /**
  * Une droite est un espace linéaire qui bissecte un espace 2D. Une droite peut
@@ -43,11 +45,24 @@ public class Droite extends Ligne {
         positionInterne2.bindBidirectional(point2.positionInterneProperty());
     }
 
+    /**
+     * Construit une droite passant par un point et une position spécifiée.
+     *
+     * @param point1 le premier point compris dans cette droite.
+     * @param position2 la deuxième position comprise dans cette droite.
+     */
+    public Droite(@NotNull final Point point1,
+            @NotNull final ObjectProperty<PositionReelle> position2) {
+        dependances.add(point1);
+        positionInterne1.bindBidirectional(point1.positionInterneProperty());
+        positionInterne2.bindBidirectional(position2);
+    }
+    
     @Override
     public Set<Forme> creerFormes() {
         final Set<Forme> formes = new HashSet<>();
         final org.graphysica.espace2d.forme.Droite forme
-                = new org.graphysica.espace2d.forme.Droite(positionInterne1, 
+                = new org.graphysica.espace2d.forme.Droite(positionInterne1,
                         positionInterne2);
         formes.add(forme);
         ajouterForme(forme);

--- a/src/main/java/org/graphysica/construction/mathematiques/Ligne.java
+++ b/src/main/java/org/graphysica/construction/mathematiques/Ligne.java
@@ -16,11 +16,9 @@
  */
 package org.graphysica.construction.mathematiques;
 
-import java.util.Set;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import org.apache.commons.math3.geometry.euclidean.twod.Vector2D;
-import org.graphysica.espace2d.forme.Forme;
 import org.graphysica.espace2d.forme.Taille;
 import org.graphysica.espace2d.position.PositionReelle;
 

--- a/src/main/java/org/graphysica/construction/mathematiques/Ligne.java
+++ b/src/main/java/org/graphysica/construction/mathematiques/Ligne.java
@@ -32,7 +32,7 @@ public abstract class Ligne extends ObjetMathematique {
     /**
      * L'épaisseur de la ligne dans sa représentation dans un espace.
      */
-    private final Taille epaisseur = Taille.de("point");
+    private final Taille epaisseur = Taille.de("ligne");
 
     /**
      * La première position interne de la ligne.

--- a/src/main/java/org/graphysica/construction/mathematiques/PointConcret.java
+++ b/src/main/java/org/graphysica/construction/mathematiques/PointConcret.java
@@ -28,6 +28,15 @@ import org.graphysica.espace2d.position.PositionReelle;
 public final class PointConcret extends Point {
 
     /**
+     * Construit un point concret à une position réelle spécifiée.
+     *
+     * @param position la position réelle du point.
+     */
+    public PointConcret(@NotNull final PositionReelle position) {
+        positionInterneProperty().setValue(position);
+    }
+
+    /**
      * Construit un point mathématique à une position réelle spécifiée.
      *
      * @param position la position réelle du point.

--- a/src/main/java/org/graphysica/construction/outil/Outil.java
+++ b/src/main/java/org/graphysica/construction/outil/Outil.java
@@ -28,7 +28,7 @@ import org.graphysica.construction.GestionnaireOutils;
  * @author Marc-Antoine Ouimet
  */
 public abstract class Outil {
-    
+
     /**
      * Le gestionnaire d'outils de la construction.
      */
@@ -49,6 +49,21 @@ public abstract class Outil {
      * @param evenement l'événement de la souris.
      */
     public abstract void gerer(@NotNull final MouseEvent evenement);
+
+    /**
+     * Détermine si l'outil est présentement en cours d'utilisation. Un outil
+     * ayant accompli sa fonction ne doit plus être en cours d'utilisation.
+     * Lorsque l'outil est en cours d'utilisation, il peut être interrompu.
+     *
+     * @return {@code true} si l'outil est en cours d'utilisation.
+     */
+    public abstract boolean isEnCours();
+
+    /**
+     * Interrompt l'outil. Annule la prévisualisation d'éléments ou l'action de
+     * l'outil, le cas échéant.
+     */
+    public abstract void interrompre();
 
     /**
      * Duplique cet outil.

--- a/src/main/java/org/graphysica/construction/outil/OutilCreationDroite.java
+++ b/src/main/java/org/graphysica/construction/outil/OutilCreationDroite.java
@@ -18,6 +18,7 @@ package org.graphysica.construction.outil;
 
 import com.sun.istack.internal.NotNull;
 import java.util.Set;
+import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import org.graphysica.construction.Element;
 import org.graphysica.construction.GestionnaireOutils;
@@ -64,15 +65,14 @@ public class OutilCreationDroite extends OutilCreationElement {
     public void gerer(@NotNull final MouseEvent evenement) {
         if (aProchaineEtape()) {
             if (point1 == null) {
-                if (evenement.getEventType() == MouseEvent.MOUSE_PRESSED
-                        && evenement.isPrimaryButtonDown()) {
+                if (evenement.getButton() == MouseButton.PRIMARY && evenement.getEventType() == MouseEvent.MOUSE_PRESSED) {
                     point1 = determinerPoint();
                 }
             } else {
                 if (point2 == null) {
                     previsualiserPoint2();
                     previsualiserDroite();
-                } else if (evenement.getEventType()
+                } else if (evenement.getButton() == MouseButton.PRIMARY && evenement.getEventType()
                         == MouseEvent.MOUSE_RELEASED) {
                     aProchaineEtape = false;
                     point2 = determinerPoint();

--- a/src/main/java/org/graphysica/construction/outil/OutilCreationDroite.java
+++ b/src/main/java/org/graphysica/construction/outil/OutilCreationDroite.java
@@ -32,6 +32,7 @@ import org.graphysica.espace2d.forme.Forme;
  * Un outil de création de droite permet de créer une droite.
  *
  * @author Marc-Antoine Ouimet
+ * @author Victor Babin
  */
 public class OutilCreationDroite extends OutilCreationElement {
 
@@ -65,14 +66,17 @@ public class OutilCreationDroite extends OutilCreationElement {
     public void gerer(@NotNull final MouseEvent evenement) {
         if (aProchaineEtape()) {
             if (point1 == null) {
-                if (evenement.getButton() == MouseButton.PRIMARY && evenement.getEventType() == MouseEvent.MOUSE_PRESSED) {
+                if (evenement.getButton() == MouseButton.PRIMARY
+                        && evenement.getEventType()
+                        == MouseEvent.MOUSE_PRESSED) {
                     point1 = determinerPoint();
                 }
             } else {
                 if (point2 == null) {
                     previsualiserPoint2();
                     previsualiserDroite();
-                } else if (evenement.getButton() == MouseButton.PRIMARY && evenement.getEventType()
+                } else if (evenement.getButton() == MouseButton.PRIMARY
+                        && evenement.getEventType()
                         == MouseEvent.MOUSE_RELEASED) {
                     aProchaineEtape = false;
                     point2 = determinerPoint();
@@ -151,6 +155,19 @@ public class OutilCreationDroite extends OutilCreationElement {
         gestionnaireOutils.getElements().add(droite);
         gestionnaireOutils.getGestionnaireCommandes().ajouter(
                 new CreerElement(gestionnaireOutils.getElements(), droite));
+    }
+
+    @Override
+    public void interrompre() {
+        if (point2 != null) {
+            point2.positionInterneProperty().unbind();
+            gestionnaireOutils.getElements().removeAll(droite, point2);
+        }
+    }
+
+    @Override
+    public boolean isEnCours() {
+        return point1 != null && aProchaineEtape;
     }
 
 }

--- a/src/main/java/org/graphysica/construction/outil/OutilCreationDroite.java
+++ b/src/main/java/org/graphysica/construction/outil/OutilCreationDroite.java
@@ -80,7 +80,6 @@ public class OutilCreationDroite extends OutilCreationElement {
                         == MouseEvent.MOUSE_RELEASED) {
                     aProchaineEtape = false;
                     point2 = determinerPoint();
-                    gestionnaireOutils.getElements().add(point2);
                     creerDroite();
                     gestionnaireOutils.finOutil();
                 }

--- a/src/main/java/org/graphysica/construction/outil/OutilCreationPoint.java
+++ b/src/main/java/org/graphysica/construction/outil/OutilCreationPoint.java
@@ -59,9 +59,11 @@ public class OutilCreationPoint extends OutilCreationElement {
             if (evenement.getButton() == MouseButton.PRIMARY
                     && evenement.getEventType() == MouseEvent.MOUSE_PRESSED) {
                 previsualiserPoint();
-            } else if (evenement.getButton() == MouseButton.PRIMARY && point != null
+            } else if (evenement.getButton() == MouseButton.PRIMARY 
+                    && point != null
                     && evenement.getEventType() == MouseEvent.MOUSE_RELEASED) {
                 creerPoint();
+                aProchaineEtape = false;
                 gestionnaireOutils.finOutil();
             }
         }
@@ -90,6 +92,18 @@ public class OutilCreationPoint extends OutilCreationElement {
         }
         gestionnaireOutils.getGestionnaireCommandes().ajouter(
                 new CreerElement(gestionnaireOutils.getElements(), point));
+    }
+
+    @Override
+    public void interrompre() {
+        if (point != null) {
+            gestionnaireOutils.getElements().remove(point);
+        }
+    }
+
+    @Override
+    public boolean isEnCours() {
+        return aProchaineEtape;
     }
 
 }

--- a/src/main/java/org/graphysica/construction/outil/OutilCreationPoint.java
+++ b/src/main/java/org/graphysica/construction/outil/OutilCreationPoint.java
@@ -17,6 +17,7 @@
 package org.graphysica.construction.outil;
 
 import com.sun.istack.internal.NotNull;
+import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import org.graphysica.construction.GestionnaireOutils;
 import org.graphysica.construction.commande.CreerElement;
@@ -55,10 +56,10 @@ public class OutilCreationPoint extends OutilCreationElement {
     @Override
     public void gerer(@NotNull final MouseEvent evenement) {
         if (aProchaineEtape()) {
-            if (evenement.isPrimaryButtonDown()
+            if (evenement.getButton() == MouseButton.PRIMARY
                     && evenement.getEventType() == MouseEvent.MOUSE_PRESSED) {
                 previsualiserPoint();
-            } else if (point != null
+            } else if (evenement.getButton() == MouseButton.PRIMARY && point != null
                     && evenement.getEventType() == MouseEvent.MOUSE_RELEASED) {
                 creerPoint();
                 gestionnaireOutils.finOutil();

--- a/src/main/java/org/graphysica/construction/outil/OutilDeplacementElement.java
+++ b/src/main/java/org/graphysica/construction/outil/OutilDeplacementElement.java
@@ -85,8 +85,7 @@ public class OutilDeplacementElement extends Outil {
         if (isEnCours()) {
             if (evenement.isMiddleButtonDown()) {
                 finDeplacement();
-            } else if (evenement.getButton() == MouseButton.PRIMARY
-                    && evenement.getEventType() == MouseEvent.MOUSE_DRAGGED) {
+            } else if (evenement.getEventType() == MouseEvent.MOUSE_DRAGGED) {
                 entame = true;
                 deplacer();
             }

--- a/src/main/java/org/graphysica/construction/outil/OutilDeplacementElement.java
+++ b/src/main/java/org/graphysica/construction/outil/OutilDeplacementElement.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.Set;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
+import org.apache.commons.math3.geometry.euclidean.twod.Vector2D;
 import org.graphysica.construction.Element;
 import org.graphysica.construction.GestionnaireOutils;
 import org.graphysica.construction.GestionnaireSelections;
@@ -32,6 +33,7 @@ import org.graphysica.espace2d.position.PositionReelle;
  * l'espace.
  *
  * @author Marc-Antoine Ouimet
+ * @author Victor Babin
  */
 public class OutilDeplacementElement extends Outil {
 
@@ -62,11 +64,21 @@ public class OutilDeplacementElement extends Outil {
         super(gestionnaireOutils);
     }
 
+    /**
+     * Détermine si un déplacement est en cours.
+     *
+     * @return {@code true} si un déplacement a été initié.
+     */
+    private boolean deplacementEnCours() {
+        return initiale != null;
+    }
+
     @Override
     public void gerer(@NotNull final MouseEvent evenement) {
         final GestionnaireSelections gestionnaireSelections
                 = gestionnaireOutils.getGestionnaireSelections();
-        if (evenement.getButton() == MouseButton.PRIMARY && evenement.getEventType() == MouseEvent.MOUSE_PRESSED
+        if (evenement.getButton() == MouseButton.PRIMARY
+                && evenement.getEventType() == MouseEvent.MOUSE_PRESSED
                 && evenement.isPrimaryButtonDown()
                 && !gestionnaireSelections.survolEstVide()) {
             initiale = gestionnaireSelections.positionReelleCurseur();
@@ -79,7 +91,8 @@ public class OutilDeplacementElement extends Outil {
                     element.deplacer(gestionnaireSelections
                             .deplacementReelCurseur());
                 }
-            } else if (evenement.getButton() == MouseButton.PRIMARY && evenement.getEventType() == MouseEvent.MOUSE_RELEASED) {
+            } else if (evenement.getButton() == MouseButton.PRIMARY
+                    && evenement.getEventType() == MouseEvent.MOUSE_RELEASED) {
                 finale = gestionnaireSelections.positionReelleCurseur();
                 gestionnaireOutils.getGestionnaireCommandes()
                         .ajouter(new DeplacerElement(elements,
@@ -90,8 +103,25 @@ public class OutilDeplacementElement extends Outil {
     }
 
     @Override
+    public void interrompre() {
+        if (deplacementEnCours()) {
+            finale = gestionnaireOutils.getGestionnaireSelections()
+                    .positionReelleCurseur();
+            final Vector2D deplacement = finale.distance(initiale);
+            for (final Element element : elements) {
+                element.deplacer(deplacement);
+            }
+        }
+    }
+
+    @Override
     public Outil dupliquer() {
         return new OutilDeplacementElement(gestionnaireOutils);
+    }
+
+    @Override
+    public boolean isEnCours() {
+        return initiale != null && finale == null;
     }
 
 }

--- a/src/main/java/org/graphysica/construction/outil/OutilDeplacementElement.java
+++ b/src/main/java/org/graphysica/construction/outil/OutilDeplacementElement.java
@@ -19,6 +19,7 @@ package org.graphysica.construction.outil;
 import com.sun.istack.internal.NotNull;
 import java.util.HashSet;
 import java.util.Set;
+import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import org.graphysica.construction.Element;
 import org.graphysica.construction.GestionnaireOutils;
@@ -65,7 +66,7 @@ public class OutilDeplacementElement extends Outil {
     public void gerer(@NotNull final MouseEvent evenement) {
         final GestionnaireSelections gestionnaireSelections
                 = gestionnaireOutils.getGestionnaireSelections();
-        if (evenement.getEventType() == MouseEvent.MOUSE_PRESSED
+        if (evenement.getButton() == MouseButton.PRIMARY && evenement.getEventType() == MouseEvent.MOUSE_PRESSED
                 && evenement.isPrimaryButtonDown()
                 && !gestionnaireSelections.survolEstVide()) {
             initiale = gestionnaireSelections.positionReelleCurseur();
@@ -78,7 +79,7 @@ public class OutilDeplacementElement extends Outil {
                     element.deplacer(gestionnaireSelections
                             .deplacementReelCurseur());
                 }
-            } else if (evenement.getEventType() == MouseEvent.MOUSE_RELEASED) {
+            } else if (evenement.getButton() == MouseButton.PRIMARY && evenement.getEventType() == MouseEvent.MOUSE_RELEASED) {
                 finale = gestionnaireSelections.positionReelleCurseur();
                 gestionnaireOutils.getGestionnaireCommandes()
                         .ajouter(new DeplacerElement(elements,

--- a/src/main/java/org/graphysica/espace2d/Espace.java
+++ b/src/main/java/org/graphysica/espace2d/Espace.java
@@ -83,7 +83,7 @@ public final class Espace extends ToileRedimensionnable
     /**
      * L'ensemble ordonné observable des formes dessinées dans l'espace.
      */
-    private final ObservableList<Forme> formes 
+    private final ObservableList<Forme> formes
             = FXCollections.observableArrayList();
 
     /**

--- a/src/main/java/org/graphysica/espace2d/ToileRedimensionnable.java
+++ b/src/main/java/org/graphysica/espace2d/ToileRedimensionnable.java
@@ -51,7 +51,7 @@ abstract class ToileRedimensionnable extends Canvas
      * @param hauteur la hauteur initiale de la toile.
      */
     public ToileRedimensionnable(final double largeur, final double hauteur) {
-        super(hauteur, hauteur);
+        super(largeur, hauteur);
     }
 
     {

--- a/src/main/java/org/graphysica/espace2d/forme/Grille.java
+++ b/src/main/java/org/graphysica/espace2d/forme/Grille.java
@@ -91,22 +91,24 @@ public final class Grille extends Forme {
     }
 
     @Override
-    public void dessinerNormal(@NotNull final Canvas toile,
+    public void dessiner(@NotNull final Canvas toile,
             @NotNull final Repere repere) {
         calculerGraduations(toile, repere);
+        super.dessiner(toile, repere);
+    }
+    
+    @Override
+    public void dessinerNormal(@NotNull final Canvas toile,
+            @NotNull final Repere repere) {
         dessinerGrille(toile, graduationsHorizontales, graduationsVerticales,
                 getCouleur(), 1);
-        if (isEnSurvol()) {
-            dessinerSurvol(toile, repere);
-        }
     }
 
     @Override
     public void dessinerSurvol(@NotNull final Canvas toile,
             @NotNull final Repere repere) {
-        calculerGraduations(toile, repere);
         dessinerGrille(toile, graduationsHorizontales, graduationsVerticales,
-                getCouleur().deriveColor(1, 1, 1, 0.2), 2);
+                getCouleur().deriveColor(1, 1, 1, 0.1), 2);
     }
 
     /**

--- a/src/main/java/org/graphysica/vue/barreoutils/BarreOutils.java
+++ b/src/main/java/org/graphysica/vue/barreoutils/BarreOutils.java
@@ -17,23 +17,9 @@
 package org.graphysica.vue.barreoutils;
 
 import com.sun.istack.internal.NotNull;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Properties;
-import javafx.event.ActionEvent;
-import javafx.scene.control.MenuButton;
-import javafx.scene.control.MenuItem;
 import javafx.scene.control.ToolBar;
-import javafx.scene.image.Image;
-import javafx.scene.image.ImageView;
 import org.graphysica.construction.GestionnaireOutils;
-import org.graphysica.construction.outil.Outil;
-import org.graphysica.construction.outil.OutilCreationDroite;
-import org.graphysica.construction.outil.OutilCreationPoint;
 import org.graphysica.construction.outil.OutilDeplacementElement;
-import org.graphysica.espace2d.forme.Taille;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Une barre d'outils permet de sélectionner des outils pour interagir avec la
@@ -42,26 +28,6 @@ import org.slf4j.LoggerFactory;
  * @author Marc-Antoine Ouimet
  */
 public final class BarreOutils extends ToolBar {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(
-            BarreOutils.class);
-
-    /**
-     * Le chemin du fichier des propriétés des items d'outil.
-     */
-    private static final String CHEMIN_PROPRIETES
-            = "/config/outil.properties";
-
-    /**
-     * Les propriétés de chemin des icônes des outils.
-     */
-    private static final Properties PROPRIETES = new Properties();
-
-    /**
-     * La dimension des icônes carrées de cette barre d'outils, exprimée en
-     * pixels.
-     */
-    private static final int DIMENSION = 32;
 
     /**
      * Le gestionnaire d'outils que contrôle cette barre d'outils.
@@ -80,117 +46,13 @@ public final class BarreOutils extends ToolBar {
         assembler();
     }
 
-    static {
-        try {
-            final InputStream entree = Taille.class
-                    .getResourceAsStream(CHEMIN_PROPRIETES);
-            if (entree == null) {
-                throw new NullPointerException();
-            } else {
-                PROPRIETES.load(entree);
-            }
-        } catch (final NullPointerException npex) {
-            LOGGER.error(
-                    "Fichier de propriétés d'outils introuvable au chemin "
-                    + CHEMIN_PROPRIETES, npex);
-        } catch (final IOException ioex) {
-            LOGGER.error("Erreur lors de la lecture du fichier de "
-                    + " propriétés au chemin " + CHEMIN_PROPRIETES, ioex);
-        }
-    }
-
     /**
      * Assemble la barre d'outils.
      */
     private void assembler() {
-        final MenuButton groupeSelection = new MenuButton();
-        final ItemOutil outilDeplacement = new ItemOutil("deplacer", "Déplacer",
-                groupeSelection, 
-                new OutilDeplacementElement(gestionnaireOutils));
-        groupeSelection.setGraphic(outilDeplacement.affichageImage());
-        groupeSelection.getItems().addAll(outilDeplacement);
-
-        final MenuButton groupePrimitif = new MenuButton();
-        final ItemOutil outilPoint = new ItemOutil("point", "Point",
-                groupePrimitif, new OutilCreationPoint(gestionnaireOutils));
-        groupePrimitif.setGraphic(outilPoint.affichageImage());
-        groupePrimitif.getItems().addAll(outilPoint);
-
-        final MenuButton groupeLignes = new MenuButton();
-        final ItemOutil outilDroite = new ItemOutil("droite", "Droite",
-                groupeLignes, new OutilCreationDroite(gestionnaireOutils));
-        groupeLignes.setGraphic(outilDroite.affichageImage());
-        groupeLignes.getItems().addAll(outilDroite);
-
-        getItems().addAll(groupeSelection, groupePrimitif, groupeLignes);
-    }
-
-    /**
-     * Un item d'outil permet de représenter un outil dans la barre d'outils.
-     */
-    private class ItemOutil extends MenuItem {
-
-        /**
-         * L'icône de cet item d'outil.
-         */
-        private final Image image;
-
-        /**
-         * Le groupement d'outils dans lequel se retrouve cet item d'outil.
-         */
-        private final MenuButton groupe;
-
-        /**
-         * L'outil généré par cet item d'outil.
-         */
-        private final Outil outil;
-
-        /**
-         * Construit un item d'outils aux attributs définis.
-         *
-         * @param propriete la propriété d'icône de cet item d'outil.
-         * @param nom le nom d'affichage de cet item d'outil.
-         * @param groupe le groupe dans lequel se retrouve cet item d'outil.
-         * @param outil l'outil généré par cet item d'outil.
-         */
-        public ItemOutil(@NotNull final String propriete,
-                @NotNull final String nom, @NotNull final MenuButton groupe,
-                @NotNull final Outil outil) {
-            super(nom);
-            this.outil = outil;
-            this.groupe = groupe;
-            final String nomFichierImage = PROPRIETES.getProperty(propriete);
-            image = new Image("/images/icons/" + nomFichierImage + ".png");
-            setGraphic(affichageImage());
-            setOnAction((ActionEvent evenement) -> {
-                gererAction();
-            });
-        }
-
-        /**
-         * Construit un affichage d'image sur l'icône de cet item d'outil.
-         *
-         * @return l'affichage d'icône de l'outil.
-         */
-        private ImageView affichageImage() {
-            final ImageView affichage = new ImageView(image);
-            affichage.setFitHeight(DIMENSION);
-            affichage.setFitWidth(DIMENSION);
-            affichage.setSmooth(true);
-            return affichage;
-        }
-
-        /**
-         * Gère l'action de cet item d'outil en actualisant l'outil sélectionné
-         * dans le gestionnaire d'outils de la construction et en remplaçant
-         * l'icône d'affichage du groupement d'outils dans lequel se retrouve
-         * cet item d'outil.
-         */
-        private void gererAction() {
-            gestionnaireOutils.setOutilActif(outil.dupliquer());
-            groupe.setGraphic(affichageImage());
-        }
-
+        getItems().addAll(new GroupeSelection(gestionnaireOutils),
+                new GroupePrimitif(gestionnaireOutils),
+                new GroupeLignes(gestionnaireOutils));
     }
 
 }

--- a/src/main/java/org/graphysica/vue/barreoutils/Groupe.java
+++ b/src/main/java/org/graphysica/vue/barreoutils/Groupe.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2018 Graphysica
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graphysica.vue.barreoutils;
+
+import com.sun.istack.internal.NotNull;
+import javafx.collections.ListChangeListener;
+import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
+import javafx.scene.control.MenuButton;
+import javafx.scene.control.MenuItem;
+import javafx.scene.input.MouseEvent;
+import org.graphysica.construction.GestionnaireOutils;
+import org.graphysica.construction.outil.Outil;
+
+/**
+ * Un groupe permet de regrouper des items d'outil selon des catégories
+ * d'utilisation. 
+ *
+ * @author Marc-Antoine Ouimet
+ */
+class Groupe extends MenuButton {
+
+    /**
+     * Le gestionnaire d'outils de ce groupe d'outils.
+     */
+    protected final GestionnaireOutils gestionnaireOutils;
+
+    /**
+     * Le denier outil utilisé dans ce groupe d'outils.
+     */
+    @NotNull
+    protected Outil dernierOutilUtilise;
+
+    /**
+     * Crée un groupe ayant un item d'outil défini.
+     *
+     * @param gestionnaireOutils le gestionnaire d'outils.
+     * @param item l'item initial du groupe.
+     */
+    public Groupe(@NotNull final GestionnaireOutils gestionnaireOutils) {
+        this.gestionnaireOutils = gestionnaireOutils;
+        getItems().addListener(changementItems);
+    }
+
+    {
+        addEventFilter(MouseEvent.MOUSE_CLICKED, new ClicGroupe());
+    }
+
+    /**
+     * L'événement d'actualisation de la liste des items du groupe.
+     */
+    private final ListChangeListener<MenuItem> changementItems = (@NotNull
+            final ListChangeListener.Change<? extends MenuItem> changements)
+            -> {
+        while (changements.next()) {
+            changements.getAddedSubList().stream().forEach((item) -> {
+                ajouter(item);
+            });
+        }
+    };
+
+    /**
+     * Ajoute un item au groupe.
+     *
+     * @param item l'item à ajouter.
+     */
+    private void ajouter(@NotNull final MenuItem item) {
+        if (item instanceof Item) {
+            final Item itemOutil = (Item) item;
+            itemOutil.setOnAction(new SelectionItem(itemOutil));
+        }
+    }
+
+    /**
+     * Définit le dernier outil utilisé par ce groupe.
+     *
+     * @param item le dernier item ayant été utilisé dans ce groupe.
+     */
+    protected void definirDernierOutil(@NotNull final Item item) {
+        dernierOutilUtilise = item.getOutil().dupliquer();
+        setGraphic(item.affichageImage());
+    }
+
+    /**
+     * Un clic sur le groupe définit l'outil actif comme étant le dernier outil
+     * ayant été utilisé dans le groupe.
+     */
+    private class ClicGroupe implements EventHandler<MouseEvent> {
+
+        @Override
+        public void handle(@NotNull final MouseEvent evenement) {
+            gestionnaireOutils.setOutilActif(dernierOutilUtilise.dupliquer());
+        }
+
+    }
+
+    /**
+     * Une sélection sur un item du groupe modifie l'outil actif du gestionnaire
+     * d'outil et redéfinit le dernier outil utilisé parmi ceux du groupe.
+     */
+    private class SelectionItem implements EventHandler<ActionEvent> {
+
+        /**
+         * L'item sélectionné.
+         */
+        private final Item item;
+
+        /**
+         * Crée une gestion de sélection d'item sur un item défini.
+         *
+         * @param item l'item dont on gère la sélection.
+         */
+        public SelectionItem(@NotNull final Item item) {
+            this.item = item;
+        }
+
+        @Override
+        public void handle(@NotNull final ActionEvent evenement) {
+            gestionnaireOutils.setOutilActif(item.getOutil().dupliquer());
+            definirDernierOutil(item);
+        }
+
+    }
+
+}

--- a/src/main/java/org/graphysica/vue/barreoutils/GroupeLignes.java
+++ b/src/main/java/org/graphysica/vue/barreoutils/GroupeLignes.java
@@ -32,8 +32,8 @@ class GroupeLignes extends Groupe {
     }
 
     {
-        final Item outilDroite = new Item(gestionnaireOutils, "droite",
-                "Droite", new OutilCreationDroite(gestionnaireOutils));
+        final Item outilDroite = new Item("droite", "Droite", 
+                new OutilCreationDroite(gestionnaireOutils));
         getItems().addAll(outilDroite);
         definirDernierOutil(outilDroite);
         setGraphic(outilDroite.affichageImage());

--- a/src/main/java/org/graphysica/vue/barreoutils/GroupeLignes.java
+++ b/src/main/java/org/graphysica/vue/barreoutils/GroupeLignes.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2018 Graphysica
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graphysica.vue.barreoutils;
+
+import com.sun.istack.internal.NotNull;
+import org.graphysica.construction.GestionnaireOutils;
+import org.graphysica.construction.outil.OutilCreationDroite;
+
+/**
+ * Le groupe d'outils de création de lignes.
+ *
+ * @author Marc-Antoine Ouimet
+ */
+class GroupeLignes extends Groupe {
+
+    public GroupeLignes(@NotNull final GestionnaireOutils gestionnaireOutils) {
+        super(gestionnaireOutils);
+    }
+
+    {
+        final Item outilDroite = new Item(gestionnaireOutils, "droite",
+                "Droite", new OutilCreationDroite(gestionnaireOutils));
+        getItems().addAll(outilDroite);
+        definirDernierOutil(outilDroite);
+        setGraphic(outilDroite.affichageImage());
+    }
+
+}

--- a/src/main/java/org/graphysica/vue/barreoutils/GroupePrimitif.java
+++ b/src/main/java/org/graphysica/vue/barreoutils/GroupePrimitif.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2018 Graphysica
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graphysica.vue.barreoutils;
+
+import com.sun.istack.internal.NotNull;
+import org.graphysica.construction.GestionnaireOutils;
+import org.graphysica.construction.outil.OutilCreationPoint;
+
+/**
+ * Le groupe des outils de création d'éléments primitif.
+ *
+ * @author Marc-Antoine Ouimet
+ */
+class GroupePrimitif extends Groupe {
+
+    public GroupePrimitif(@NotNull final GestionnaireOutils gestionnaireOutils) {
+        super(gestionnaireOutils);
+    }
+
+    {
+        final Item outilPoint = new Item(gestionnaireOutils, "point",
+                "Point", new OutilCreationPoint(gestionnaireOutils));
+        getItems().addAll(outilPoint);
+        definirDernierOutil(outilPoint);
+        setGraphic(outilPoint.affichageImage());
+    }
+
+}

--- a/src/main/java/org/graphysica/vue/barreoutils/GroupePrimitif.java
+++ b/src/main/java/org/graphysica/vue/barreoutils/GroupePrimitif.java
@@ -32,8 +32,8 @@ class GroupePrimitif extends Groupe {
     }
 
     {
-        final Item outilPoint = new Item(gestionnaireOutils, "point",
-                "Point", new OutilCreationPoint(gestionnaireOutils));
+        final Item outilPoint = new Item("point", "Point", 
+                new OutilCreationPoint(gestionnaireOutils));
         getItems().addAll(outilPoint);
         definirDernierOutil(outilPoint);
         setGraphic(outilPoint.affichageImage());

--- a/src/main/java/org/graphysica/vue/barreoutils/GroupeSelection.java
+++ b/src/main/java/org/graphysica/vue/barreoutils/GroupeSelection.java
@@ -32,8 +32,8 @@ class GroupeSelection extends Groupe {
     }
 
     {
-        final Item outilDeplacement = new Item(gestionnaireOutils, "deplacer",
-                "Déplacer", new OutilDeplacementElement(gestionnaireOutils));
+        final Item outilDeplacement = new Item("deplacer", "Déplacer", 
+                new OutilDeplacementElement(gestionnaireOutils));
         getItems().addAll(outilDeplacement);
         definirDernierOutil(outilDeplacement);
         setGraphic(outilDeplacement.affichageImage());

--- a/src/main/java/org/graphysica/vue/barreoutils/GroupeSelection.java
+++ b/src/main/java/org/graphysica/vue/barreoutils/GroupeSelection.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2018 Graphysica
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graphysica.vue.barreoutils;
+
+import com.sun.istack.internal.NotNull;
+import org.graphysica.construction.GestionnaireOutils;
+import org.graphysica.construction.outil.OutilDeplacementElement;
+
+/**
+ * Le groupe des outils de sélection.
+ *
+ * @author Marc-Antoine Ouimet
+ */
+class GroupeSelection extends Groupe {
+
+    public GroupeSelection(@NotNull final GestionnaireOutils gestionnaireOutils) {
+        super(gestionnaireOutils);
+    }
+
+    {
+        final Item outilDeplacement = new Item(gestionnaireOutils, "deplacer",
+                "Déplacer", new OutilDeplacementElement(gestionnaireOutils));
+        getItems().addAll(outilDeplacement);
+        definirDernierOutil(outilDeplacement);
+        setGraphic(outilDeplacement.affichageImage());
+    }
+
+}

--- a/src/main/java/org/graphysica/vue/barreoutils/Item.java
+++ b/src/main/java/org/graphysica/vue/barreoutils/Item.java
@@ -23,7 +23,6 @@ import java.util.Properties;
 import javafx.scene.control.MenuItem;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import org.graphysica.construction.GestionnaireOutils;
 import org.graphysica.construction.outil.Outil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,7 +32,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Marc-Antoine Ouimet
  */
-class Item extends MenuItem {
+final class Item extends MenuItem {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Item.class);
 
@@ -55,11 +54,6 @@ class Item extends MenuItem {
     private static final int DIMENSION = 32;
     
     /**
-     * Le gestionnaire d'outils sur lequel cet item d'outil interagit.
-     */
-    private final GestionnaireOutils gestionnaireOutils;
-
-    /**
      * L'icône de cet item d'outil.
      */
     private final Image image;
@@ -73,18 +67,13 @@ class Item extends MenuItem {
     /**
      * Construit un item d'outils aux attributs définis.
      *
-     * @param gestionnaireOutils le gestionnaire d'outils sur lequel cet item
-     * d'outil interagit.
      * @param propriete la propriété d'icône de cet item d'outil.
      * @param nom le nom d'affichage de cet item d'outil.
      * @param outil l'outil généré par cet item d'outil.
      */
-    public Item(
-            @NotNull final GestionnaireOutils gestionnaireOutils,
-            @NotNull final String propriete,
+    public Item(@NotNull final String propriete,
             @NotNull final String nom, @NotNull final Outil outil) {
         super(nom);
-        this.gestionnaireOutils = gestionnaireOutils;
         this.outil = outil;
         final String nomFichierImage = PROPRIETES.getProperty(propriete);
         image = new Image("/images/icons/" + nomFichierImage + ".png");

--- a/src/main/java/org/graphysica/vue/barreoutils/Item.java
+++ b/src/main/java/org/graphysica/vue/barreoutils/Item.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2018 Graphysica
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graphysica.vue.barreoutils;
+
+import com.sun.istack.internal.NotNull;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import javafx.scene.control.MenuItem;
+import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
+import org.graphysica.construction.GestionnaireOutils;
+import org.graphysica.construction.outil.Outil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Un item d'outil permet de représenter un outil dans la barre d'outils.
+ *
+ * @author Marc-Antoine Ouimet
+ */
+class Item extends MenuItem {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Item.class);
+
+    /**
+     * Le chemin du fichier des propriétés des items d'outil.
+     */
+    private static final String CHEMIN_PROPRIETES
+            = "/config/outil.properties";
+
+    /**
+     * Les propriétés de chemin des icônes des outils.
+     */
+    private static final Properties PROPRIETES = new Properties();
+
+    /**
+     * La dimension des icônes carrées de cette barre d'outils, exprimée en
+     * pixels.
+     */
+    private static final int DIMENSION = 32;
+    
+    /**
+     * Le gestionnaire d'outils sur lequel cet item d'outil interagit.
+     */
+    private final GestionnaireOutils gestionnaireOutils;
+
+    /**
+     * L'icône de cet item d'outil.
+     */
+    private final Image image;
+
+
+    /**
+     * L'outil généré par cet item d'outil.
+     */
+    private final Outil outil;
+
+    /**
+     * Construit un item d'outils aux attributs définis.
+     *
+     * @param gestionnaireOutils le gestionnaire d'outils sur lequel cet item
+     * d'outil interagit.
+     * @param propriete la propriété d'icône de cet item d'outil.
+     * @param nom le nom d'affichage de cet item d'outil.
+     * @param outil l'outil généré par cet item d'outil.
+     */
+    public Item(
+            @NotNull final GestionnaireOutils gestionnaireOutils,
+            @NotNull final String propriete,
+            @NotNull final String nom, @NotNull final Outil outil) {
+        super(nom);
+        this.gestionnaireOutils = gestionnaireOutils;
+        this.outil = outil;
+        final String nomFichierImage = PROPRIETES.getProperty(propriete);
+        image = new Image("/images/icons/" + nomFichierImage + ".png");
+        setGraphic(affichageImage());
+    }
+
+    static {
+        try {
+            final InputStream entree = Item.class
+                    .getResourceAsStream(CHEMIN_PROPRIETES);
+            if (entree == null) {
+                throw new NullPointerException();
+            } else {
+                PROPRIETES.load(entree);
+            }
+        }
+        catch (final NullPointerException npex) {
+            LOGGER.error(
+                    "Fichier de propriétés d'outils introuvable au chemin "
+                    + CHEMIN_PROPRIETES, npex);
+        }
+        catch (final IOException ioex) {
+            LOGGER.error("Erreur lors de la lecture du fichier de "
+                    + " propriétés au chemin " + CHEMIN_PROPRIETES, ioex);
+        }
+    }
+
+    /**
+     * Construit un affichage d'image sur l'icône de cet item d'outil.
+     *
+     * @return l'affichage d'icône de l'outil.
+     */
+    ImageView affichageImage() {
+        final ImageView affichage = new ImageView(image);
+        affichage.setFitHeight(DIMENSION);
+        affichage.setFitWidth(DIMENSION);
+        affichage.setSmooth(true);
+        return affichage;
+    }
+
+    Outil getOutil() {
+        return outil;
+    }
+    
+}


### PR DESCRIPTION
Les outils ont été revus pour ne fonctionner qu'avec le clic principal de la souris.
Les espaces peuvent dorénavant être navigué à l'aide des raccourcis `Ctrl+'+'`, `Ctrl+'-'`, `Ctrl+'UP'`, `Ctrl+'DOWN'`, `Ctrl+'LEFT'`, `Ctrl+'RIGHT'`,
La barre d'outils a été réusinée pour la rendre plus pratique et maintenable.
Plusieurs autres correctifs ont été appliqués.