### PR TITLE
Passage de listes à ensembles observables

### DIFF
--- a/src/main/java/org/graphysica/construction/Construction.java
+++ b/src/main/java/org/graphysica/construction/Construction.java
@@ -16,8 +16,10 @@
  */
 package org.graphysica.construction;
 
+import java.util.HashSet;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.collections.ObservableSet;
 import org.graphysica.espace2d.Espace;
 
 /**
@@ -30,15 +32,15 @@ public final class Construction {
     /**
      * Les espaces de la construction.
      */
-    private final ObservableList<Espace> espaces
-            = FXCollections.observableArrayList();
+    private final ObservableSet<Espace> espaces
+            = FXCollections.observableSet(new HashSet<>());
 
     /**
      * L'ensemble des éléments de la construction. Comprend les corps physiques
      * et les objets mathématiques.
      */
-    private final ObservableList<Element> elements
-            = FXCollections.observableArrayList();
+    private final ObservableSet<Element> elements
+            = FXCollections.observableSet(new HashSet<>());
 
     /**
      * Le gestionnaire des commandes de la construction.
@@ -69,11 +71,11 @@ public final class Construction {
         espaces.add(new Espace(500, 500));
     }
 
-    public ObservableList<Espace> getEspaces() {
+    public ObservableSet<Espace> getEspaces() {
         return espaces;
     }
 
-    public ObservableList<Element> getElements() {
+    public ObservableSet<Element> getElements() {
         return elements;
     }
 

--- a/src/main/java/org/graphysica/construction/GestionnaireCommandes.java
+++ b/src/main/java/org/graphysica/construction/GestionnaireCommandes.java
@@ -16,6 +16,7 @@
  */
 package org.graphysica.construction;
 
+import org.graphysica.util.StackLimite;
 import com.sun.istack.internal.NotNull;
 import java.util.Stack;
 import org.graphysica.construction.commande.Commande;

--- a/src/main/java/org/graphysica/construction/commande/CreerElement.java
+++ b/src/main/java/org/graphysica/construction/commande/CreerElement.java
@@ -17,7 +17,9 @@
 package org.graphysica.construction.commande;
 
 import com.sun.istack.internal.NotNull;
-import javafx.collections.ObservableList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import org.graphysica.construction.Element;
 
 /**
@@ -34,12 +36,12 @@ public class CreerElement extends CommandeAnnulable {
     /**
      * L'ensemble des éléments de la construction.
      */
-    private final ObservableList<Element> construction;
+    private final Set<Element> elementsConstruction;
 
     /**
      * Les éléments à créer par cette commande.
      */
-    private final Element[] elements;
+    private final Set<Element> elements;
 
     /**
      * Construit une commande de création d'éléments sur un ensemble d'éléments
@@ -49,10 +51,10 @@ public class CreerElement extends CommandeAnnulable {
      * les éléments.
      * @param elements les éléments à créer.
      */
-    public CreerElement(@NotNull final ObservableList<Element> construction,
+    public CreerElement(@NotNull final Set<Element> construction,
             @NotNull final Element... elements) {
-        this.elements = elements;
-        this.construction = construction;
+        this.elements = new HashSet<>(Arrays.asList(elements));
+        this.elementsConstruction = construction;
     }
 
     /**
@@ -60,7 +62,7 @@ public class CreerElement extends CommandeAnnulable {
      */
     @Override
     public void executer() {
-        construction.addAll(elements);
+        elementsConstruction.addAll(elements);
     }
 
     /**
@@ -68,7 +70,7 @@ public class CreerElement extends CommandeAnnulable {
      */
     @Override
     public void annuler() {
-        construction.removeAll(elements);
+        elementsConstruction.removeAll(elements);
     }
 
     /**

--- a/src/main/java/org/graphysica/construction/outil/OutilCreationDroite.java
+++ b/src/main/java/org/graphysica/construction/outil/OutilCreationDroite.java
@@ -17,6 +17,7 @@
 package org.graphysica.construction.outil;
 
 import com.sun.istack.internal.NotNull;
+import java.util.Collection;
 import java.util.Set;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
@@ -157,7 +158,9 @@ public class OutilCreationDroite extends OutilCreationElement {
         droite.positionInterne2Property().unbindBidirectional(
                 gestionnaireOutils.getGestionnaireSelections()
                 .positionCurseurProperty());
-        gestionnaireOutils.getElements().removeAll(droite, point2);
+        final Collection<Element> elements = gestionnaireOutils.getElements();
+        elements.remove(droite);
+        elements.remove(point2);
     }
 
     @Override

--- a/src/main/java/org/graphysica/espace2d/Repere.java
+++ b/src/main/java/org/graphysica/espace2d/Repere.java
@@ -46,7 +46,17 @@ public final class Repere {
             = new SimpleObjectProperty<>(Vector2D.ZERO);
 
     /**
-     * L'échelle de l'espace exprimée en pixels par mètre.
+     * L'échelle minimale d'un repère d'espace, exprimée en pixels par mètre.
+     */
+    private static final Vector2D ECHELLE_MINIMALE = new Vector2D(1e-21, 1e-12);
+
+    /**
+     * L'échelle maximale d'un repère d'espace, exprimée en pixels par mètre.
+     */
+    private static final Vector2D ECHELLE_MAXIMALE = new Vector2D(1e21, 1e21);
+
+    /**
+     * L'échelle d'un repère d'espace, exprimée en pixels par mètre.
      */
     private final ObjectProperty<Vector2D> echelle
             = new SimpleObjectProperty<>(new Vector2D(100, 100));
@@ -376,12 +386,21 @@ public final class Repere {
     }
 
     /**
-     * Modifie la valeur d'échelle de ce repère.
+     * Modifie la valeur d'échelle de ce repère. Contraint l'échelle entre
+     * {@code ECHELLE_MINIMALE} et {@code ECHELLE_MAXIMALE}.
      *
      * @param echelle l'échelle de ce repère, exprimée en pixels par mètre.
      */
     public void setEchelle(@NotNull final Vector2D echelle) {
-        this.echelle.setValue(echelle);
+        if (echelle.getX() > ECHELLE_MAXIMALE.getX()
+                || echelle.getY() > ECHELLE_MAXIMALE.getY()) {
+            this.echelle.setValue(ECHELLE_MAXIMALE);
+        } else if (echelle.getX() < ECHELLE_MINIMALE.getX()
+                || echelle.getY() < ECHELLE_MINIMALE.getY()) {
+            this.echelle.setValue(ECHELLE_MINIMALE);
+        } else {
+            this.echelle.setValue(echelle);
+        }
     }
 
     public ObjectProperty<Vector2D> echelleProperty() {

--- a/src/main/java/org/graphysica/espace2d/forme/Axe.java
+++ b/src/main/java/org/graphysica/espace2d/forme/Axe.java
@@ -156,12 +156,13 @@ abstract class Axe extends Forme {
     /**
      * Actualise la quantité d'étiquettes requises pour le tracé de cet axe.
      *
+     * @param repere le repère d'affichage de cet axe.
      * @param valeurs l'ensemble des valeurs représentées par les étiquettes.
      * @param format le format d'affichage des valeurs d'étiquettes.
      */
-    protected void actualiserEtiquettes(@NotNull double[] valeurs,
-            final String format) {
-        valeurs = valeursSansZero(valeurs);
+    protected void actualiserEtiquettes(@NotNull final Repere repere, 
+            @NotNull double[] valeurs, final String format) {
+        valeurs = valeursSansZero(repere, valeurs);
         retirerEtiquettesObsoletes(valeurs);
         ajouterEtiquettes(valeurs, format);
     }
@@ -173,32 +174,8 @@ abstract class Axe extends Forme {
      * @param valeurs l'ensemble des valeurs représentées par les étiquettes.
      * @return les valeurs de graduation sans le zéro.
      */
-    private double[] valeursSansZero(@NotNull final double[] valeurs) {
-        if (valeurs[0] < 0 && valeurs[valeurs.length - 1] > 0) {
-            /**
-             * Les valeurs contiennent un et un seul zéro qui correspond au
-             * minimum des valeurs absolues.
-             */
-            final double[] valeursFiltrees = new double[valeurs.length - 1];
-            double minimumAbsolu = Double.MAX_VALUE;
-            for (final double valeur : valeurs) {
-                final double valeurAbsolue = Math.abs(valeur);
-                if (valeurAbsolue < minimumAbsolu) {
-                    minimumAbsolu = valeurAbsolue;
-                }
-            }
-            int i = 0;
-            for (final double valeur : valeurs) {
-                if (Math.abs(valeur) != minimumAbsolu) {
-                    valeursFiltrees[i] = valeur;
-                    i++;
-                }
-            }
-            return valeursFiltrees;
-        } else {
-            return valeurs;
-        }
-    }
+    protected abstract double[] valeursSansZero(@NotNull final Repere repere, 
+            @NotNull final double[] valeurs);
 
     /**
      * Retire les étiquettes de cet axe dont les valeurs ne sont pas comprises

--- a/src/main/java/org/graphysica/espace2d/forme/AxeHorizontal.java
+++ b/src/main/java/org/graphysica/espace2d/forme/AxeHorizontal.java
@@ -17,6 +17,7 @@
 package org.graphysica.espace2d.forme;
 
 import com.sun.istack.internal.NotNull;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
 import javafx.scene.canvas.Canvas;
@@ -54,7 +55,7 @@ public class AxeHorizontal extends Axe {
                 .graduationsVerticales(toile.getWidth(), getEspacement());
         final double[] abscissesReelles = repere.abscissesReelles(
                 graduationsVerticales);
-        actualiserEtiquettes(abscissesReelles, formatValeurs(repere));
+        actualiserEtiquettes(repere, abscissesReelles, formatValeurs(repere));
         final double positionReelleAxe = positionReelleAxe(toile, repere);
         setOrigine(new PositionReelle(
                 new Vector2D(repere.abscisseReelle(0), positionReelleAxe)));
@@ -68,6 +69,28 @@ public class AxeHorizontal extends Axe {
         etiquettes.values().forEach((etiquette) -> {
             etiquette.dessiner(toile, repere);
         });
+    }
+
+    @Override
+    protected double[] valeursSansZero(@NotNull final Repere repere, 
+            @NotNull final double[] valeurs) {
+        final double zero = repere.abscisseReelle(repere.abscisseVirtuelle(0));
+        for (int i = 0; i < valeurs.length; i++) {
+            if (Math.abs(zero - valeurs[i]) <= 1e-9) {
+                final double[] valeursFiltrees = new double[valeurs.length - 1];
+                if (i != 0) {
+                    System.arraycopy(valeurs, 0, 
+                            valeursFiltrees, 0, i);
+                    System.arraycopy(valeurs, i + 1, 
+                            valeursFiltrees, i, valeurs.length - 1 - i);
+                } else {
+                    System.arraycopy(valeurs, 1, 
+                            valeursFiltrees, i, valeurs.length - 1 - i);
+                }
+                return valeursFiltrees;
+            }
+        }
+        return valeurs;
     }
 
     @Override
@@ -94,7 +117,7 @@ public class AxeHorizontal extends Axe {
     protected double espacementMinimalReel(@NotNull final Repere repere) {
         return getEspacement() / repere.getEchelle().getX();
     }
-
+    
     /**
      * Actualise la position des étiquettes de cet axe.
      *

--- a/src/main/java/org/graphysica/espace2d/forme/AxeVertical.java
+++ b/src/main/java/org/graphysica/espace2d/forme/AxeVertical.java
@@ -17,6 +17,7 @@
 package org.graphysica.espace2d.forme;
 
 import com.sun.istack.internal.NotNull;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
 import javafx.scene.canvas.Canvas;
@@ -54,7 +55,7 @@ public class AxeVertical extends Axe {
                 .graduationsHorizontales(toile.getHeight(), getEspacement());
         final double[] ordonneesReelles = repere.ordonneesReellees(
                 graduationsHorizontales);
-        actualiserEtiquettes(ordonneesReelles, formatValeurs(repere));
+        actualiserEtiquettes(repere, ordonneesReelles, formatValeurs(repere));
         final double positionReelleAxe = positionReelleAxe(toile, repere);
         setOrigine(new PositionReelle(new Vector2D(positionReelleAxe,
                 repere.ordonneeReelle(toile.getHeight()))));
@@ -67,6 +68,28 @@ public class AxeVertical extends Axe {
         etiquettes.values().forEach((etiquette) -> {
             etiquette.dessiner(toile, repere);
         });
+    }
+
+    @Override
+    protected double[] valeursSansZero(@NotNull final Repere repere,
+            @NotNull final double[] valeurs) {
+        final double zero = repere.ordonneeReelle(repere.ordonneeVirtuelle(0));
+        for (int i = 0; i < valeurs.length; i++) {
+            if (Math.abs(zero - valeurs[i]) <= 1e-9) {
+                final double[] valeursFiltrees = new double[valeurs.length - 1];
+                if (i != 0) {
+                    System.arraycopy(valeurs, 0, 
+                            valeursFiltrees, 0, i);
+                    System.arraycopy(valeurs, i + 1, 
+                            valeursFiltrees, i, valeurs.length - 1 - i);
+                } else {
+                    System.arraycopy(valeurs, 1, 
+                            valeursFiltrees, i, valeurs.length - 1 - i);
+                }
+                return valeursFiltrees;
+            }
+        }
+        return valeurs;
     }
 
     @Override

--- a/src/main/java/org/graphysica/espace2d/forme/Forme.java
+++ b/src/main/java/org/graphysica/espace2d/forme/Forme.java
@@ -19,9 +19,9 @@ package org.graphysica.espace2d.forme;
 import com.sun.istack.internal.NotNull;
 import java.util.HashSet;
 import java.util.Set;
-import javafx.beans.Observable;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.Property;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.canvas.Canvas;
@@ -44,7 +44,7 @@ public abstract class Forme implements Dessinable, Survolable, Selectionnable,
      * alors la forme doit être redessinée pour l'ensemble des espaces qui
      * l'affichent.
      */
-    protected final Set<Observable> proprietes = new HashSet<>();
+    protected final Set<Property> proprietes = new HashSet<>();
 
     /**
      * La couleur d'affichage de la forme.
@@ -110,7 +110,7 @@ public abstract class Forme implements Dessinable, Survolable, Selectionnable,
         return distance(curseur, repere) <= DISTANCE_SELECTION;
     }
 
-    public Set<Observable> getProprietes() {
+    public Set<Property> getProprietes() {
         return proprietes;
     }
 

--- a/src/main/java/org/graphysica/util/SetChangeListener.java
+++ b/src/main/java/org/graphysica/util/SetChangeListener.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2018 Graphysica
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graphysica.util;
+
+import com.sun.istack.internal.NotNull;
+import javafx.collections.ObservableSet;
+
+/**
+ * Gère les notifications de modifications d'ajout et de retrait d'éléments d'un
+ * ensemble observable.
+ *
+ * @author Marc-Antoine Ouimet
+ * @param <E> le type d'élément de l'ensemble observable.
+ */
+public abstract class SetChangeListener<E>
+        implements javafx.collections.SetChangeListener<E> {
+
+    /**
+     * Construit un événement d'actualisation d'ensemble observable.
+     */
+    public SetChangeListener() {
+    }
+
+    /**
+     * Construit un événement d'actualisation d'ensemble observable en gérant
+     * l'ajout des éléments spécifiés.
+     *
+     * @param elements les éléments à gérer.
+     */
+    public SetChangeListener(@NotNull final ObservableSet<E> elements) {
+        elements.stream().forEach((element) -> {
+            onAdd(element);
+        });
+    }
+
+    @Override
+    public void onChanged(@NotNull final Change changement) {
+        if (changement.wasAdded()) {
+            onAdd((E) changement.getElementAdded());
+        } else if (changement.wasRemoved()) {
+            onRemove((E) changement.getElementRemoved());
+        }
+    }
+
+    /**
+     * Appelée à chaque ajout sur l'ensemble observable.
+     *
+     * @param element l'élément ajouté à l'ensemble observable.
+     */
+    public abstract void onAdd(@NotNull final E element);
+
+    /**
+     * Appelée à chaque retrait de l'ensemble observable.
+     *
+     * @param element l'élément retirer de l'ensmble observable.
+     */
+    public abstract void onRemove(@NotNull final E element);
+
+}

--- a/src/main/java/org/graphysica/util/StackLimite.java
+++ b/src/main/java/org/graphysica/util/StackLimite.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graphysica.construction;
+package org.graphysica.util;
 
 import com.sun.istack.internal.NotNull;
 import java.util.Stack;

--- a/src/main/java/org/graphysica/vue/AffichageConstruction.java
+++ b/src/main/java/org/graphysica/vue/AffichageConstruction.java
@@ -19,8 +19,8 @@ package org.graphysica.vue;
 import com.sun.istack.internal.NotNull;
 import java.util.HashMap;
 import java.util.Map;
-import javafx.collections.ListChangeListener;
-import javafx.collections.ObservableList;
+import javafx.collections.ObservableSet;
+import javafx.collections.SetChangeListener;
 import javafx.scene.control.SplitPane;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
@@ -113,7 +113,7 @@ public class AffichageConstruction extends BorderPane {
          * de construction.
          */
         public AffichageEspaces() {
-            final ObservableList<Espace> espaces = construction.getEspaces();
+            final ObservableSet<Espace> espaces = construction.getEspaces();
             espaces.addListener(changementEspaces);
             espaces.forEach((espace) -> {
                 ajouter(espace);
@@ -123,19 +123,16 @@ public class AffichageConstruction extends BorderPane {
         }
 
         /**
-         * L'événement de modification de la liste des espaces de la
+         * L'événement de modification de l'ensemble des espaces de la
          * construction. Permet d'ajouter à l'affichage des espaces un nouveau
          * panneau lié aux dimensions de l'espace dupliqué.
          */
-        private final ListChangeListener<Espace> changementEspaces = (@NotNull
-                final ListChangeListener.Change<? extends Espace> changements) -> {
-            while (changements.next()) {
-                changements.getAddedSubList().stream().forEach((espace) -> {
-                    ajouter(espace);
-                });
-                changements.getRemoved().stream().forEach((espace) -> {
-                    retirer(espace);
-                });
+        private final SetChangeListener<Espace> changementEspaces = (@NotNull
+                final SetChangeListener.Change<? extends Espace> changement) -> {
+            if (changement.wasAdded()) {
+                ajouter(changement.getElementAdded());
+            } else if (changement.wasRemoved()) {
+                retirer(changement.getElementRemoved());
             }
         };
 

--- a/src/main/java/org/graphysica/vue/inspecteur/Inspecteur.java
+++ b/src/main/java/org/graphysica/vue/inspecteur/Inspecteur.java
@@ -17,7 +17,7 @@
 package org.graphysica.vue.inspecteur;
 
 import com.sun.istack.internal.NotNull;
-import javafx.collections.ObservableList;
+import javafx.collections.ObservableSet;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
 import org.graphysica.construction.Construction;
@@ -43,7 +43,7 @@ public class Inspecteur extends TabPane {
     /**
      * L'ensemble des éléments de la construction.
      */
-    private final ObservableList<Element> elements;
+    private final ObservableSet<Element> elements;
 
     /**
      * L'inspecteur des objets de la construction relevant de la mathématique.

--- a/src/main/java/org/graphysica/vue/inspecteur/InspecteurElements.java
+++ b/src/main/java/org/graphysica/vue/inspecteur/InspecteurElements.java
@@ -17,7 +17,7 @@
 package org.graphysica.vue.inspecteur;
 
 import com.sun.istack.internal.NotNull;
-import javafx.collections.ObservableList;
+import javafx.collections.ObservableSet;
 import javafx.scene.layout.VBox;
 import org.graphysica.construction.Element;
 
@@ -32,7 +32,7 @@ abstract class InspecteurElements extends VBox {
     /**
      * L'ensemble des éléments de la construction.
      */
-    protected final ObservableList<Element> elements;
+    protected final ObservableSet<Element> elements;
 
     /**
      * Construit un inspecteur d'éléments sur un ensemble défini d'éléments de
@@ -40,7 +40,7 @@ abstract class InspecteurElements extends VBox {
      *
      * @param elements les éléments à inspecter dans la construction.
      */
-    public InspecteurElements(@NotNull final ObservableList<Element> elements) {
+    public InspecteurElements(@NotNull final ObservableSet<Element> elements) {
         this.elements = elements;
     }
 

--- a/src/main/java/org/graphysica/vue/inspecteur/InspecteurMathematique.java
+++ b/src/main/java/org/graphysica/vue/inspecteur/InspecteurMathematique.java
@@ -17,11 +17,12 @@
 package org.graphysica.vue.inspecteur;
 
 import com.sun.istack.internal.NotNull;
+import java.util.HashSet;
 import javafx.collections.FXCollections;
-import javafx.collections.ListChangeListener;
-import javafx.collections.ObservableList;
+import javafx.collections.ObservableSet;
 import org.graphysica.construction.Element;
 import org.graphysica.construction.mathematiques.ObjetMathematique;
+import org.graphysica.util.SetChangeListener;
 
 /**
  * Un inspecteur de mathématique permet d'éditer les détails des objets
@@ -35,8 +36,8 @@ class InspecteurMathematique extends InspecteurElements {
      * L'ensemble des objets mathématiques parmi les éléments de la
      * construction.
      */
-    private final ObservableList<ObjetMathematique> objetsMathematiques
-            = FXCollections.observableArrayList();
+    private final ObservableSet<ObjetMathematique> objetsMathematiques
+            = FXCollections.observableSet(new HashSet<>());
 
     /**
      * Construit un inspecteur de mathématique sur un ensemble d'éléments de la
@@ -44,33 +45,39 @@ class InspecteurMathematique extends InspecteurElements {
      *
      * @param elements les éléments à inspecter de la construction.
      */
-    public InspecteurMathematique(ObservableList<Element> elements) {
+    public InspecteurMathematique(
+            @NotNull final ObservableSet<Element> elements) {
         super(elements);
-        elements.addListener(changementElements);
-        for (final Element element : elements) {
-            if (element instanceof ObjetMathematique) {
-                objetsMathematiques.add((ObjetMathematique) element);
-            }
-        }
+        elements.addListener(new ElementsListener(elements));
     }
 
     /**
      * L'événement de changement des éléments de la construction.
      */
-    private final ListChangeListener<Element> changementElements = (@NotNull
-            final ListChangeListener.Change<? extends Element> changements) -> {
-        while (changements.next()) {
-            changements.getAddedSubList().stream().forEach((element) -> {
-                if (element instanceof ObjetMathematique) {
-                    objetsMathematiques.add((ObjetMathematique) element);
-                }
-            });
-            changements.getRemoved().stream().forEach((element) -> {
-                if (element instanceof ObjetMathematique) {
-                    objetsMathematiques.remove((ObjetMathematique) element);
-                }
-            });
+    private class ElementsListener extends SetChangeListener<Element> {
+        
+        /**
+         * {@inheritDoc}
+         */
+        public ElementsListener(
+                @NotNull final ObservableSet<Element> elements) {
+            super(elements);
         }
-    };
+
+        @Override
+        public void onAdd(@NotNull final Element element) {
+            if (element instanceof ObjetMathematique) {
+                objetsMathematiques.add((ObjetMathematique) element);
+            }
+        }
+
+        @Override
+        public void onRemove(@NotNull final Element element) {
+            if (element instanceof ObjetMathematique) {
+                objetsMathematiques.remove((ObjetMathematique) element);
+            }
+        }
+        
+    }
 
 }

--- a/src/main/java/org/graphysica/vue/inspecteur/InspecteurPhysiques.java
+++ b/src/main/java/org/graphysica/vue/inspecteur/InspecteurPhysiques.java
@@ -17,11 +17,12 @@
 package org.graphysica.vue.inspecteur;
 
 import com.sun.istack.internal.NotNull;
+import java.util.HashSet;
 import javafx.collections.FXCollections;
-import javafx.collections.ListChangeListener;
-import javafx.collections.ObservableList;
+import javafx.collections.ObservableSet;
 import org.graphysica.construction.Element;
 import org.graphysica.physique.Corps;
+import org.graphysica.util.SetChangeListener;
 
 /**
  * Un inspecteur de physique permet d'éditer les détails des corps physiques de
@@ -34,8 +35,8 @@ class InspecteurPhysiques extends InspecteurElements {
     /**
      * L'ensemble des corps physiques parmi les éléments de la construction.
      */
-    private final ObservableList<Corps> corpsPhysiques
-            = FXCollections.observableArrayList();
+    private final ObservableSet<Corps> corpsPhysiques
+            = FXCollections.observableSet(new HashSet<>());
 
     /**
      * Construit un inspecteur de physique sur un ensemble d'éléments de la
@@ -43,33 +44,38 @@ class InspecteurPhysiques extends InspecteurElements {
      *
      * @param elements les éléments à inspecter de la construction.
      */
-    public InspecteurPhysiques(ObservableList<Element> elements) {
+    public InspecteurPhysiques(@NotNull final ObservableSet<Element> elements) {
         super(elements);
-        elements.addListener(changementElements);
-        for (final Element element : elements) {
-            if (element instanceof Corps) {
-                corpsPhysiques.add((Corps) element);
-            }
-        }
+        elements.addListener(new ElementsListener(elements));
     }
 
     /**
      * L'événement de changement des éléments de la construction.
      */
-    private final ListChangeListener<Element> changementElements = (@NotNull
-            final ListChangeListener.Change<? extends Element> changements) -> {
-        while (changements.next()) {
-            changements.getAddedSubList().stream().forEach((element) -> {
-                if (element instanceof Corps) {
-                    corpsPhysiques.add((Corps) element);
-                }
-            });
-            changements.getRemoved().stream().forEach((element) -> {
-                if (element instanceof Corps) {
-                    corpsPhysiques.remove((Corps) element);
-                }
-            });
+    private class ElementsListener extends SetChangeListener<Element> {
+        
+        /**
+         * {@inheritDoc}
+         */
+        public ElementsListener(
+                @NotNull final ObservableSet<Element> elements) {
+            super(elements);
         }
-    };
+
+        @Override
+        public void onAdd(@NotNull final Element element) {
+            if (element instanceof Corps) {
+                corpsPhysiques.add((Corps) element);
+            }
+        }
+
+        @Override
+        public void onRemove(@NotNull final Element element) {
+            if (element instanceof Corps) {
+                corpsPhysiques.remove((Corps) element);
+            }
+        }
+        
+    }
 
 }


### PR DESCRIPTION
Ce correctif propose une modification de toutes les utilisations de listes observables vers des ensembles observables. Ce faisant, les éléments et espaces d'une construction ne peuvent pas être répétés dans leur collection. Une instance de `org.graphysica.util.SetChangeListener` permet de créer un événement sur les ajouts et les retraits sur les instances de `javafx.collections.ObservableSet` comprenant déjà des éléments en faisant appel sur chacun d'eux la méthode `org.graphysica.util.SetChangeListener::onAdd()`.