### PR TITLE
Implémentation primitive d'un inspecteur d'objets mathématiques

### DIFF
--- a/src/main/java/org/graphysica/construction/Element.java
+++ b/src/main/java/org/graphysica/construction/Element.java
@@ -22,6 +22,8 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
 import org.apache.commons.math3.geometry.euclidean.twod.Vector2D;
 import org.graphysica.espace2d.forme.Forme;
 
@@ -31,6 +33,11 @@ import org.graphysica.espace2d.forme.Forme;
  * @author Marc-Antoine Ouimet
  */
 public abstract class Element implements Deplaceable {
+
+    /**
+     * Le module d'étiquettage des éléments.
+     */
+    private static final Etiquettage ETIQUETTAGE = new Etiquettage();
 
     /**
      * La propriété d'affichage de cet élément à l'écran.
@@ -52,6 +59,12 @@ public abstract class Element implements Deplaceable {
      * Le nombre d'éléments qui ont été construits.
      */
     private static final AtomicInteger ELEMENTS = new AtomicInteger(0);
+
+    /**
+     * L'étiquette de l'élément.
+     */
+    protected StringProperty etiquette = new SimpleStringProperty(
+            ETIQUETTAGE.prochaineEtiquette());
 
     /**
      * Le numéro d'identification de l'élément.
@@ -142,13 +155,47 @@ public abstract class Element implements Deplaceable {
     public boolean isLie() {
         return false;
     }
-    
+
     public Set<Element> getDependances() {
         return dependances;
     }
 
     public final BooleanProperty afficheProperty() {
         return affiche;
+    }
+
+    /**
+     * Un module d'édiquettage permet de générer un nombre indéterminé
+     * d'étiquettes ordonnées.
+     */
+    private static class Etiquettage {
+
+        /**
+         * Le compteur en indice des étiquettes.
+         */
+        private int compteur = 0;
+
+        /**
+         * La lettre de l'étiquette.
+         */
+        private char lettre = 'A';
+
+        /**
+         * Crée la prochaine étiquette.
+         *
+         * @return le texte de l'étiquette.
+         */
+        public String prochaineEtiquette() {
+            final String etiquette = lettre + "_{" + compteur + "}";
+            if (lettre == 'Z') {
+                lettre = 'A';
+                compteur++;
+            } else {
+                lettre++;
+            }
+            return etiquette;
+        }
+
     }
 
 }

--- a/src/main/java/org/graphysica/construction/mathematiques/Droite.java
+++ b/src/main/java/org/graphysica/construction/mathematiques/Droite.java
@@ -66,6 +66,7 @@ public class Droite extends Ligne {
                         positionInterne2);
         formes.add(forme);
         ajouterForme(forme);
+        formes.addAll(super.creerFormes());
         return formes;
     }
 

--- a/src/main/java/org/graphysica/construction/mathematiques/Droite.java
+++ b/src/main/java/org/graphysica/construction/mathematiques/Droite.java
@@ -63,7 +63,7 @@ public class Droite extends Ligne {
         final Set<Forme> formes = new HashSet<>();
         final org.graphysica.espace2d.forme.Droite forme
                 = new org.graphysica.espace2d.forme.Droite(positionInterne1,
-                        positionInterne2);
+                        positionInterne2, couleurProperty());
         formes.add(forme);
         ajouterForme(forme);
         formes.addAll(super.creerFormes());

--- a/src/main/java/org/graphysica/construction/mathematiques/DroiteParallele.java
+++ b/src/main/java/org/graphysica/construction/mathematiques/DroiteParallele.java
@@ -123,6 +123,7 @@ public class DroiteParallele extends Ligne {
                         positionInterne2);
         formes.add(forme);
         ajouterForme(forme);
+        formes.addAll(super.creerFormes());
         return formes;
     }
 

--- a/src/main/java/org/graphysica/construction/mathematiques/DroiteParallele.java
+++ b/src/main/java/org/graphysica/construction/mathematiques/DroiteParallele.java
@@ -120,7 +120,7 @@ public class DroiteParallele extends Ligne {
         final Set<Forme> formes = new HashSet<>();
         final org.graphysica.espace2d.forme.Droite forme
                 = new org.graphysica.espace2d.forme.Droite(positionInterne1,
-                        positionInterne2);
+                        positionInterne2, couleurProperty());
         formes.add(forme);
         ajouterForme(forme);
         formes.addAll(super.creerFormes());

--- a/src/main/java/org/graphysica/construction/mathematiques/DroitePerpendiculaire.java
+++ b/src/main/java/org/graphysica/construction/mathematiques/DroitePerpendiculaire.java
@@ -123,7 +123,7 @@ public class DroitePerpendiculaire extends Ligne {
         final Set<Forme> formes = new HashSet<>();
         final org.graphysica.espace2d.forme.Droite forme
                 = new org.graphysica.espace2d.forme.Droite(positionInterne1,
-                        positionInterne2);
+                        positionInterne2, couleurProperty());
         formes.add(forme);
         ajouterForme(forme);
         formes.addAll(super.creerFormes());

--- a/src/main/java/org/graphysica/construction/mathematiques/DroitePerpendiculaire.java
+++ b/src/main/java/org/graphysica/construction/mathematiques/DroitePerpendiculaire.java
@@ -126,6 +126,7 @@ public class DroitePerpendiculaire extends Ligne {
                         positionInterne2);
         formes.add(forme);
         ajouterForme(forme);
+        formes.addAll(super.creerFormes());
         return formes;
     }
 

--- a/src/main/java/org/graphysica/construction/mathematiques/Ligne.java
+++ b/src/main/java/org/graphysica/construction/mathematiques/Ligne.java
@@ -16,9 +16,13 @@
  */
 package org.graphysica.construction.mathematiques;
 
+import java.util.HashSet;
+import java.util.Set;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import org.apache.commons.math3.geometry.euclidean.twod.Vector2D;
+import org.graphysica.espace2d.forme.Etiquette;
+import org.graphysica.espace2d.forme.Forme;
 import org.graphysica.espace2d.forme.Taille;
 import org.graphysica.espace2d.position.PositionReelle;
 
@@ -45,6 +49,18 @@ public abstract class Ligne extends ObjetMathematique {
      */
     protected final ObjectProperty<PositionReelle> positionInterne2
             = new SimpleObjectProperty<>(new PositionReelle(Vector2D.ZERO));
+
+    @Override
+    public Set<Forme> creerFormes() {
+        final Set<Forme> formes = new HashSet<>();
+        final Etiquette etiquette = new Etiquette(
+                this.etiquette, 
+                positionInterne1, 
+                new Vector2D(5, 25));
+        formes.add(etiquette);
+        ajouterForme(etiquette);
+        return formes;
+    }
     
     public ObjectProperty<PositionReelle> positionInterne1Property() {
         return positionInterne1;

--- a/src/main/java/org/graphysica/construction/mathematiques/ObjetMathematique.java
+++ b/src/main/java/org/graphysica/construction/mathematiques/ObjetMathematique.java
@@ -36,7 +36,8 @@ public abstract class ObjetMathematique extends Element
     /**
      * La couleur de cet objet mathématique.
      */
-    private final ObjectProperty<Color> couleur = new SimpleObjectProperty<>();
+    private final ObjectProperty<Color> couleur = new SimpleObjectProperty<>(
+            Color.BLACK);
 
     public final ObjectProperty<Color> couleurProperty() {
         return couleur;

--- a/src/main/java/org/graphysica/construction/mathematiques/Point.java
+++ b/src/main/java/org/graphysica/construction/mathematiques/Point.java
@@ -23,6 +23,7 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.paint.Color;
 import org.apache.commons.math3.geometry.euclidean.twod.Vector2D;
+import org.graphysica.espace2d.forme.Etiquette;
 import org.graphysica.espace2d.forme.Forme;
 import org.graphysica.espace2d.forme.Taille;
 import org.graphysica.espace2d.position.PositionReelle;
@@ -45,13 +46,8 @@ public abstract class Point extends ObjetMathematique {
      */
     protected final Taille taille = Taille.de("point");
 
-    /**
-     * La couleur par défaut des points.
-     */
-    protected static final Color COULEUR_PAR_DEFAUT = Color.BLUE;
-
     {
-        couleurProperty().setValue(COULEUR_PAR_DEFAUT);
+        couleurProperty().setValue(Color.BLUE);
     }
 
     @Override
@@ -63,6 +59,10 @@ public abstract class Point extends ObjetMathematique {
                         tailleProperty());
         formes.add(forme);
         ajouterForme(forme);
+        final Etiquette etiquette = new Etiquette(this.etiquette, 
+                positionInterne);
+        formes.add(etiquette);
+        ajouterForme(etiquette);
         return formes;
     }
 

--- a/src/main/java/org/graphysica/construction/mathematiques/SegmentDroite.java
+++ b/src/main/java/org/graphysica/construction/mathematiques/SegmentDroite.java
@@ -70,6 +70,7 @@ public class SegmentDroite extends Ligne {
                         positionInterne1, positionInterne2);
         formes.add(forme);
         ajouterForme(forme);
+        formes.addAll(super.creerFormes());
         return formes;
     }
 

--- a/src/main/java/org/graphysica/construction/mathematiques/SegmentDroite.java
+++ b/src/main/java/org/graphysica/construction/mathematiques/SegmentDroite.java
@@ -67,7 +67,7 @@ public class SegmentDroite extends Ligne {
         final Set<Forme> formes = new HashSet<>();
         final org.graphysica.espace2d.forme.SegmentDroite forme
                 = new org.graphysica.espace2d.forme.SegmentDroite(
-                        positionInterne1, positionInterne2);
+                        positionInterne1, positionInterne2, couleurProperty());
         formes.add(forme);
         ajouterForme(forme);
         formes.addAll(super.creerFormes());

--- a/src/main/java/org/graphysica/espace2d/forme/Droite.java
+++ b/src/main/java/org/graphysica/espace2d/forme/Droite.java
@@ -19,6 +19,7 @@ package org.graphysica.espace2d.forme;
 import com.sun.istack.internal.NotNull;
 import javafx.beans.property.ObjectProperty;
 import javafx.scene.canvas.Canvas;
+import javafx.scene.paint.Color;
 import org.apache.commons.math3.geometry.euclidean.twod.Segment;
 import org.apache.commons.math3.geometry.euclidean.twod.Vector2D;
 import org.graphysica.espace2d.position.Position;
@@ -41,6 +42,20 @@ public final class Droite extends Ligne {
     public Droite(@NotNull final ObjectProperty<? extends Position> position1,
             @NotNull final ObjectProperty<? extends Position> position2) {
         super(position1, position2);
+    }
+
+    /**
+     * Construit une droite passant par deux position définies.
+     *
+     * @param position1 la première position.
+     * @param position2 la deuxième position.
+     * @param couleur la couleur de la droite.
+     */
+    public Droite(@NotNull final ObjectProperty<? extends Position> position1,
+            @NotNull final ObjectProperty<? extends Position> position2,
+            @NotNull final ObjectProperty<Color> couleur) {
+        this(position1, position2);
+        couleurProperty().bind(couleur);
     }
 
     /**
@@ -85,7 +100,7 @@ public final class Droite extends Ligne {
                     new Vector2D(xQ, toile.getHeight())); // Q
         }
     }
-    
+
     @Override
     public double distance(@NotNull final Position curseur,
             @NotNull final Repere repere) {

--- a/src/main/java/org/graphysica/espace2d/forme/Etiquette.java
+++ b/src/main/java/org/graphysica/espace2d/forme/Etiquette.java
@@ -155,6 +155,69 @@ public class Etiquette extends Forme {
         this(texte, positionAncrage);
         this.tailleCaracteres.bind(tailleCaracters);
     }
+    
+    /**
+     * Construit une étiquette ancrée à une position d'ancrage définie.
+     *
+     * @param texte le texte de l'étiquette.
+     * @param positionAncrage la position d'ancrage de l'étiquette.
+     * @param couleur la couleur du texte de l'étiquette.
+     */
+    public Etiquette(@NotNull final StringProperty texte,
+            @NotNull final ObjectProperty<? extends Position> positionAncrage,
+            @NotNull final ObjectProperty<Color> couleur) {
+        this(texte, positionAncrage);
+        couleurProperty().bind(couleur);
+    }
+    
+    /**
+     * Construit une étiquette ancrée à une position d'ancrage définie.
+     *
+     * @param texte le texte de l'étiquette.
+     * @param positionAncrage la position d'ancrage de l'étiquette.
+     * @param positionRelative la position relative de l'étiquette.
+     * @param couleur la couleur du texte de l'étiquette.
+     */
+    public Etiquette(@NotNull final StringProperty texte,
+            @NotNull final ObjectProperty<? extends Position> positionAncrage,
+            @NotNull final Vector2D positionRelative,
+            @NotNull final ObjectProperty<Color> couleur) {
+        this(texte, positionAncrage);
+        setPositionRelative(positionRelative);
+        couleurProperty().bind(couleur);
+    }
+    
+    /**
+     * Construit une étiquette ancrée à une position d'ancrage définie.
+     *
+     * @param texte le texte de l'étiquette.
+     * @param positionAncrage la position d'ancrage de l'étiquette.
+     * @param positionRelative la position relative de l'étiquette.
+     */
+    public Etiquette(@NotNull final StringProperty texte,
+            @NotNull final ObjectProperty<? extends Position> positionAncrage,
+            @NotNull final Vector2D positionRelative) {
+        this(texte, positionAncrage);
+        setPositionRelative(positionRelative);
+    }
+    
+    /**
+     * Construit une étiquette ancrée à une position d'ancrage définie.
+     *
+     * @param texte le texte de l'étiquette.
+     * @param positionAncrage la position d'ancrage de l'étiquette.
+     * @param tailleCaracters la taille des caractères du texte de l'étiquette,
+     * exprimée en points.
+     * @param couleur la couleur du texte de l'étiquette.
+     */
+    public Etiquette(@NotNull final StringProperty texte,
+            @NotNull final ObjectProperty<? extends Position> positionAncrage,
+            @NotNull final IntegerProperty tailleCaracters,
+            @NotNull final ObjectProperty<Color> couleur) {
+        this(texte, positionAncrage);
+        this.tailleCaracteres.bind(tailleCaracters);
+        couleurProperty().bind(couleur);
+    }
 
     static {
         TeXFormula.setDefaultDPI();
@@ -177,6 +240,7 @@ public class Etiquette extends Forme {
     private void actualiserContexteGraphique(@NotNull final Canvas toile) {
         if (contexteGraphique == null
                 || dernierContexteGraphique != toile.getGraphicsContext2D()) {
+            toile.getGraphicsContext2D().setFill(getCouleur());
             contexteGraphique = new FXGraphics2D(toile.getGraphicsContext2D());
         }
     }
@@ -203,10 +267,10 @@ public class Etiquette extends Forme {
         final Vector2D coinSuperieurGauche = coinSuperieurGauche(repere)
                 .virtuelle(repere);
         final GraphicsContext contexteGraphique = toile.getGraphicsContext2D();
-        contexteGraphique.setStroke(getCouleur());
+        contexteGraphique.setStroke(getCouleur().deriveColor(0, 0, 0, 0.1));
         contexteGraphique.setLineWidth(1);
-        contexteGraphique.strokeRect(coinSuperieurGauche.getX(),
-                coinSuperieurGauche.getY(), getLargeur(), getHauteur());
+        contexteGraphique.strokeRoundRect(coinSuperieurGauche.getX(),
+                coinSuperieurGauche.getY(), getLargeur(), getHauteur(), 5, 5);
     }
 
     /**

--- a/src/main/java/org/graphysica/espace2d/forme/SegmentDroite.java
+++ b/src/main/java/org/graphysica/espace2d/forme/SegmentDroite.java
@@ -19,6 +19,7 @@ package org.graphysica.espace2d.forme;
 import com.sun.istack.internal.NotNull;
 import javafx.beans.property.ObjectProperty;
 import javafx.scene.canvas.Canvas;
+import javafx.scene.paint.Color;
 import org.apache.commons.math3.geometry.euclidean.twod.Segment;
 import org.apache.commons.math3.geometry.euclidean.twod.Vector2D;
 import org.graphysica.espace2d.position.Position;
@@ -41,6 +42,21 @@ public class SegmentDroite extends Ligne {
             @NotNull final ObjectProperty<? extends Position> position1,
             @NotNull final ObjectProperty<? extends Position> position2) {
         super(position1, position2);
+    }
+
+    /**
+     * Construit un segment de droite reliant deux positions.
+     *
+     * @param position1 la première position du segment de droite.
+     * @param position2 la deuxième position du segment de droite.
+     * @param couleur la couleur du segment de droite.
+     */
+    public SegmentDroite(
+            @NotNull final ObjectProperty<? extends Position> position1,
+            @NotNull final ObjectProperty<? extends Position> position2,
+            @NotNull final ObjectProperty<Color> couleur) {
+        this(position1, position2);
+        couleurProperty().bind(couleur);
     }
 
     @Override

--- a/src/main/java/org/graphysica/vue/inspecteur/Inspecteur.java
+++ b/src/main/java/org/graphysica/vue/inspecteur/Inspecteur.java
@@ -61,7 +61,7 @@ public final class Inspecteur extends TabPane {
     /**
      * L'inspecteur des objets de la construction relevant de la physique.
      */
-    private final InspecteurPhysiques inspecteurPhysique;
+    private final InspecteurPhysique inspecteurPhysique;
 
     /**
      * Construit un inspecteur d'éléments sur une construction définie.
@@ -77,7 +77,7 @@ public final class Inspecteur extends TabPane {
         final Tab ongletMathematique = new Tab("Mathématique",
                 panneauMathematiques);
         ongletMathematique.setClosable(false);
-        inspecteurPhysique = new InspecteurPhysiques(elements);
+        inspecteurPhysique = new InspecteurPhysique(elements);
         final ScrollPane panneauPhysiques = panneauDeroulantVertical();
         panneauPhysiques.setContent(inspecteurPhysique);
         final Tab ongletPhysique = new Tab("Physique", panneauPhysiques);
@@ -93,7 +93,7 @@ public final class Inspecteur extends TabPane {
      */
     private static ScrollPane panneauDeroulantVertical() {
         final ScrollPane panneau = new ScrollPane();
-        panneau.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
+        panneau.setFitToWidth(true);
         return panneau;
     }
 

--- a/src/main/java/org/graphysica/vue/inspecteur/InspecteurElements.java
+++ b/src/main/java/org/graphysica/vue/inspecteur/InspecteurElements.java
@@ -18,6 +18,7 @@ package org.graphysica.vue.inspecteur;
 
 import com.sun.istack.internal.NotNull;
 import javafx.collections.ObservableSet;
+import javafx.geometry.Orientation;
 import javafx.scene.layout.VBox;
 import org.graphysica.construction.Element;
 
@@ -42,6 +43,7 @@ abstract class InspecteurElements extends VBox {
      */
     public InspecteurElements(@NotNull final ObservableSet<Element> elements) {
         this.elements = elements;
+        setFillWidth(true);
     }
 
 }

--- a/src/main/java/org/graphysica/vue/inspecteur/InspecteurMathematique.java
+++ b/src/main/java/org/graphysica/vue/inspecteur/InspecteurMathematique.java
@@ -17,9 +17,16 @@
 package org.graphysica.vue.inspecteur;
 
 import com.sun.istack.internal.NotNull;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableSet;
+import javafx.scene.Node;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.ColorPicker;
+import javafx.scene.control.TitledPane;
+import javafx.scene.layout.VBox;
 import org.graphysica.construction.Element;
 import org.graphysica.construction.mathematiques.ObjetMathematique;
 import org.graphysica.util.SetChangeListener;
@@ -48,6 +55,8 @@ final class InspecteurMathematique extends InspecteurElements {
     public InspecteurMathematique(
             @NotNull final ObservableSet<Element> elements) {
         super(elements);
+        objetsMathematiques.addListener(new ObjetsMathematiquesListener(
+                objetsMathematiques));
         elements.addListener(new ElementsListener(elements));
     }
 
@@ -55,7 +64,7 @@ final class InspecteurMathematique extends InspecteurElements {
      * L'événement de changement des éléments de la construction.
      */
     private class ElementsListener extends SetChangeListener<Element> {
-        
+
         /**
          * {@inheritDoc}
          */
@@ -77,7 +86,78 @@ final class InspecteurMathematique extends InspecteurElements {
                 objetsMathematiques.remove((ObjetMathematique) element);
             }
         }
-        
+
+    }
+
+    /**
+     * L'événement de changement des objets mathématiques de l'inspecteur.
+     */
+    private class ObjetsMathematiquesListener
+            extends SetChangeListener<ObjetMathematique> {
+
+        /**
+         * L'association des panneaux d'information aux objets mathématiques.
+         */
+        private final Map<ObjetMathematique, Node> informations
+                = new HashMap<>();
+
+        /**
+         * {@inheritDoc}
+         */
+        public ObjetsMathematiquesListener(
+                @NotNull final ObservableSet<ObjetMathematique> elements) {
+            super(elements);
+        }
+
+        @Override
+        public void onAdd(@NotNull final ObjetMathematique element) {
+            final Node panneau = panneauInformations(element);
+            informations.put(element, panneau);
+            getChildren().add(panneau);
+        }
+
+        /**
+         * Crée un panneau d'informations d'un élément défini.
+         *
+         * @param element l'élément représenté.
+         * @return la panneau d'informations généré.
+         */
+        private Node panneauInformations(
+                @NotNull final ObjetMathematique element) {
+            final TitledPane panneau = new TitledPane();
+            panneau.setAnimated(false);
+            panneau.setExpanded(false);
+            panneau.setText("Élément #" + element.getId());
+            panneau.setContent(contenuInformations(element));
+            return panneau;
+        }
+
+        /**
+         * Crée le contenu d'un panneau d'informations d'un élément défini.
+         *
+         * @param element l'élément représenté.
+         * @return le contenu des contrôles d'édition des informations de
+         * l'élément.
+         */
+        private VBox contenuInformations(
+                @NotNull final ObjetMathematique element) {
+            final VBox contenu = new VBox();
+            final CheckBox affiche = new CheckBox("Affiché");
+            affiche.selectedProperty().bindBidirectional(
+                    element.afficheProperty());
+            contenu.getChildren().add(affiche);
+            final ColorPicker couleur = new ColorPicker();
+            couleur.valueProperty().bindBidirectional(
+                    element.couleurProperty());
+            contenu.getChildren().add(couleur);
+            return contenu;
+        }
+
+        @Override
+        public void onRemove(@NotNull final ObjetMathematique element) {
+            getChildren().remove(informations.remove(element));
+        }
+
     }
 
 }

--- a/src/main/java/org/graphysica/vue/inspecteur/InspecteurPhysique.java
+++ b/src/main/java/org/graphysica/vue/inspecteur/InspecteurPhysique.java
@@ -30,7 +30,7 @@ import org.graphysica.util.SetChangeListener;
  *
  * @author Marc-Antoine Ouimet
  */
-final class InspecteurPhysiques extends InspecteurElements {
+final class InspecteurPhysique extends InspecteurElements {
 
     /**
      * L'ensemble des corps physiques parmi les éléments de la construction.
@@ -44,7 +44,7 @@ final class InspecteurPhysiques extends InspecteurElements {
      *
      * @param elements les éléments à inspecter de la construction.
      */
-    public InspecteurPhysiques(@NotNull final ObservableSet<Element> elements) {
+    public InspecteurPhysique(@NotNull final ObservableSet<Element> elements) {
         super(elements);
         elements.addListener(new ElementsListener(elements));
     }


### PR DESCRIPTION
Les éléments sont dorénavant étiquetés.
L'inspecteur des objets mathématiques permet de modifier la couleur et l'affichage des éléments mathématiques de la construction.